### PR TITLE
Update label extraction regex to handle unix path

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -32,7 +32,7 @@ export function activate(context: vscode.ExtensionContext) {
 			options.push(fileName);
 		});
 		quickPick.items = options.map(label => ({
-			label: label.match(/^.*\\(.*)\..*$/)[1],
+			label: label.match(/^.*[\\\/](.*)\..*$/)[1],
 			description: label,
 			alwaysShow: Configuration.fuzzySearch()
 		}));
@@ -42,7 +42,7 @@ export function activate(context: vscode.ExtensionContext) {
 			quickPick.onDidChangeValue(selection => {
 				const fuzzysortItems = fuzzysort.go(selection, options);
 				quickPick.items = fuzzysortItems.map(item => ({
-					label: item.target.match(/^.*\\(.*)\..*$/)[1],
+					label: item.target.match(/^.*[\\\/](.*)\..*$/)[1],
 					description: item.target,
 					alwaysShow: true
 				}));


### PR DESCRIPTION
The regex applied to the editor label to extract the file name has been
updated to accept `/` or `\`.